### PR TITLE
Add command to call RelatedSpec(V)Open

### DIFF
--- a/plugin/spec-finder.vim
+++ b/plugin/spec-finder.vim
@@ -36,5 +36,8 @@ function! RelatedSpecVOpen()
   endif
 endfunction
 
-nnoremap <silent> <C-s> :call RelatedSpecVOpen()<CR>
-nnoremap <silent> ,<C-s> :call RelatedSpecOpen()<CR>
+command! RelatedSpecVOpen call RelatedSpecVOpen()
+command! RelatedSpecOpen call RelatedSpecOpen()
+
+nnoremap <silent> <C-s> :RelatedSpecVOpen<CR>
+nnoremap <silent> ,<C-s> :RelatedSpecOpen<CR>


### PR DESCRIPTION
Now you can use `:RelatedSpecOpen` and `:RelatedSpecVOpen` to call the corresponding functions. I updated the mappings, too.

BTW: I couldn't get this to run. If I call one of these functions, my VIM doesn't do anything, which I can see. For example no buffer is opened after calling.
_I think this isn't the right place to get help?!_
